### PR TITLE
Pass `proof` & `instance` by reference; avoid resizing twice

### DIFF
--- a/src/aurora/mod.rs
+++ b/src/aurora/mod.rs
@@ -355,7 +355,6 @@ where
             c,
             num_constraints: n,
             num_instance_variables,
-            num_witness_variables,
             ..
         } = matrices;
 
@@ -375,10 +374,6 @@ where
                 expected: *unpadded_num_instance_variables,
             });
         }
-
-        // Resize the instance to the padded length
-        let mut zero_padded_instance = instance.clone();
-        zero_padded_instance.resize(num_instance_variables + num_witness_variables, F::ZERO);
 
         // Absorb the first 5 commitments
         sponge.absorb(&large_coms.iter().take(5).collect::<Vec<_>>());
@@ -449,7 +444,7 @@ where
         //  - a one-time inner product of size n per call.
         let h_evaluate_interpolator = |evals: &Vec<F>| inner_product(&evals, &lagrange_basis_evals);
 
-        let v_star_a = h_evaluate_interpolator(&zero_padded_instance);
+        let v_star_a = h_evaluate_interpolator(&instance);
 
         let v_h_in_a: F = h
             .elements()

--- a/src/aurora/mod.rs
+++ b/src/aurora/mod.rs
@@ -442,7 +442,8 @@ where
         //  - a one-time evaluation of the Lagrange basis over h at a_point
         //    (lagrange_basis_evals), which is amortised over all calls
         //  - a one-time inner product of size n per call.
-        let h_evaluate_interpolator = |evals: &Vec<F>| inner_product(&evals, &lagrange_basis_evals);
+        let h_evaluate_interpolator =
+            |evals: &Vec<F>| inner_product(&evals, &lagrange_basis_evals[0..evals.len()]);
 
         let v_star_a = h_evaluate_interpolator(&instance);
 

--- a/src/aurora/mod.rs
+++ b/src/aurora/mod.rs
@@ -328,7 +328,7 @@ where
 
     pub fn verify<PCS: PolynomialCommitment<F, DensePolynomial<F>>>(
         vk: &AuroraVerifierKey<F, PCS>,
-        instance: Vec<F>,
+        instance: &Vec<F>,
         aurora_proof: AuroraProof<F, PCS>,
         sponge: &mut impl CryptographicSponge,
     ) -> Result<bool, AuroraError<F, PCS>> {
@@ -377,8 +377,8 @@ where
         }
 
         // Resize the instance to the padded length
-        let mut instance = instance;
-        instance.resize(num_instance_variables, F::ZERO);
+        let mut zero_padded_instance = instance.clone();
+        zero_padded_instance.resize(num_instance_variables + num_witness_variables, F::ZERO);
 
         // Absorb the first 5 commitments
         sponge.absorb(&large_coms.iter().take(5).collect::<Vec<_>>());
@@ -440,9 +440,6 @@ where
         }
 
         // ======================== Univariate sumcheck test ========================
-        let zero_padded_instance =
-            [instance.clone(), vec![F::ZERO; num_witness_variables]].concat();
-
         let lagrange_basis_evals = h.evaluate_all_lagrange_coefficients(a_point);
 
         // Returns f(a_point), where f is the unique polynomial of degree < n that

--- a/src/aurora/mod.rs
+++ b/src/aurora/mod.rs
@@ -329,7 +329,7 @@ where
     pub fn verify<PCS: PolynomialCommitment<F, DensePolynomial<F>>>(
         vk: &AuroraVerifierKey<F, PCS>,
         instance: &Vec<F>,
-        aurora_proof: AuroraProof<F, PCS>,
+        aurora_proof: &AuroraProof<F, PCS>,
         sponge: &mut impl CryptographicSponge,
     ) -> Result<bool, AuroraError<F, PCS>> {
         let AuroraVerifierKey {
@@ -395,7 +395,7 @@ where
 
         if !PCS::check(
             vk_large,
-            &large_coms,
+            large_coms,
             &a_point,
             large_evals.clone(),
             &large_opening_proof,
@@ -409,9 +409,9 @@ where
 
         if !PCS::check(
             vk_small,
-            &[com_g_2],
+            [com_g_2],
             &a_point,
-            vec![g_2_a],
+            [*g_2_a],
             &g_2_opening_proof,
             sponge,
             None,
@@ -476,7 +476,7 @@ where
             + (p_r_a * f_b_a - q_br_a * f_z_a) * r_pow_n
             + (p_r_a * f_c_a - q_cr_a * f_z_a) * (r_pow_n * r_pow_n);
 
-        Ok(u_a == g_1_a * v_h_a + g_2_a * a_point)
+        Ok(u_a == g_1_a * v_h_a + *g_2_a * a_point)
     }
 
     // Returns the internal R1CS. Note that it is padded upon calling

--- a/src/aurora/tests.rs
+++ b/src/aurora/tests.rs
@@ -185,7 +185,7 @@ fn test_prove() {
     assert!(AuroraR1CS::verify::<TestUVLigero<Fr>>(
         &vk,
         &instance,
-        aurora_proof,
+        &aurora_proof,
         &mut sponge.clone()
     )
     .unwrap());

--- a/src/aurora/tests.rs
+++ b/src/aurora/tests.rs
@@ -184,7 +184,7 @@ fn test_prove() {
 
     assert!(AuroraR1CS::verify::<TestUVLigero<Fr>>(
         &vk,
-        instance,
+        &instance,
         aurora_proof,
         &mut sponge.clone()
     )

--- a/src/aurora/utils.rs
+++ b/src/aurora/utils.rs
@@ -8,6 +8,7 @@ use ark_poly::{
 };
 use ark_poly_commit::{LabeledPolynomial, PolynomialCommitment};
 use ark_relations::r1cs::{ConstraintMatrices, ConstraintSystem, LinearCombination, Matrix};
+use itertools::zip_eq;
 
 // Returns x^n as a DensePolynomial
 pub(crate) fn monomial<F: PrimeField>(n: usize) -> DensePolynomial<F> {
@@ -132,7 +133,7 @@ pub(crate) fn label_polynomials<F: PrimeField>(
 }
 
 pub(crate) fn inner_product<F: PrimeField>(v1: &[F], v2: &[F]) -> F {
-    v1.iter().zip(v2).map(|(li, ri)| *li * ri).sum()
+    zip_eq(v1.iter(), v2.iter()).map(|(li, ri)| *li * ri).sum()
 }
 
 pub(crate) fn is_padded<F: PrimeField>(r1cs: &ConstraintSystem<F>) -> bool {


### PR DESCRIPTION
1. resize vectors only once
2. aurora `verify` shouldn't need to consume the proof nor instance, pass refs now